### PR TITLE
Package updates

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -274,13 +274,13 @@ jobs:
         creds: ${{ secrets.AZURE_SP }}     
       #Swap staging slots with prod
     - name: Swap web service staging slot to production
-      uses: Azure/cli@v1.0.8
+      uses: Azure/cli@v2.0.0
       with:
         inlineScript: az webapp deployment slot swap --name "devops-prod-eu-service" --resource-group "devopsmetrics" --slot staging --target-slot production
     - name: Deploy web service app settings
       run: az webapp config appsettings set --name "devops-prod-eu-service" --resource-group "devopsmetrics" --settings "AppSettings:AzureDevOpsPatToken=${{ secrets.AzureDevOpsPATToken }}" "AppSettings:GitHubClientId=${{ secrets.GitHubClientId }}" "AppSettings:GitHubClientSecret=${{ secrets.GitHubClientSecret }}" "AppSettings:AzureStorageAccountConfigurationString=${{ secrets.AzureStorageConnectionString }}"     
     - name: Swap web site staging slot to production
-      uses: Azure/cli@v1.0.8
+      uses: Azure/cli@v2.0.0
       with:
         inlineScript: az webapp deployment slot swap --name "devops-prod-eu-web" --resource-group "devopsmetrics" --slot staging --target-slot production
     - name: Deploy website app settings

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,11 +20,11 @@ jobs:
         fetch-depth: 0 #fetch-depth is needed for GitVersion  
     #Install and calculate the new version with GitVersion  
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.10.2
+      uses: gittools/actions/gitversion/setup@v1.1.1
       with:
         versionSpec: 5.x
     - name: Determine Version
-      uses: gittools/actions/gitversion/execute@v0.10.2
+      uses: gittools/actions/gitversion/execute@v1.1.1
       id: gitversion # step id used as reference for output values
     - name: Display GitVersion outputs
       run: |

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -132,7 +132,7 @@ jobs:
     if: github.ref == 'refs/heads/main' 
     steps:
       - name: Run Sonarcloud test
-        uses: samsmithnz/SamsDotNetSonarCloudAction@v2.1.0
+        uses: samsmithnz/SamsDotNetSonarCloudAction@v2.1
         with:
           projects: 'src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj,src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj,src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj,src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj,src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj,src/DevOpsMetrics.Web/DevOpsMetrics.Web.csproj,src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj'
           dotnet-version: '8.0.x'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -151,7 +151,7 @@ jobs:
 #    steps:        
 #    # Login with the secret SP details
 #    - name: Log into Azure
-#      uses: azure/login@v1
+#      uses: azure/login@v2
 #      with:
 #        creds: ${{ secrets.AZURE_SP_PROBOT }}  
 #    - name: Download webapp artifact
@@ -179,7 +179,7 @@ jobs:
     steps:        
     # Login with the secret SP details
     - name: Log into Azure
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_SP }}  
     
@@ -269,7 +269,7 @@ jobs:
     steps:
     # Login with the secret SP details
     - name: Log into Azure
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_SP }}     
       #Swap staging slots with prod

--- a/src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj
+++ b/src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Azure.Identity" Version="1.10.4" />
-	  <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-	  <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+	  <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+	  <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
+++ b/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.2" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj
+++ b/src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
 		<PackageReference Include="Azure.Identity" Version="1.10.4" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\DevOpsMetrics.Core\DevOpsMetrics.Core.csproj" />

--- a/src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj
+++ b/src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.16.2" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="120.0.6099.10900" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.18.1" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="123.0.6312.8600" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj
+++ b/src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj
@@ -7,12 +7,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Data.Tables" Version="12.8.2" />
+		<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
 		<PackageReference Include="Azure.Identity" Version="1.10.4" />
-		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj
+++ b/src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj
@@ -21,19 +21,19 @@
 	<ItemGroup>
 
 		<PackageReference Include="Azure.Identity" Version="1.10.4" />
-		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
-		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/dotnetcore.yml` file and several `.csproj` files under the `src` directory. The changes mainly involve updating the versions of various dependencies and actions used in the GitHub workflow and the projects.

GitHub Actions version updates:

* [`.github/workflows/dotnetcore.yml`](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L23-R27): Updated the version of `gittools/actions/gitversion/setup` and `gittools/actions/gitversion/execute` from `v0.10.2` to `v1.1.1`.
* [`.github/workflows/dotnetcore.yml`](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L135-R135): Updated the version of `samsmithnz/SamsDotNetSonarCloudAction` from `v2.1.0` to `v2.1`.
* [`.github/workflows/dotnetcore.yml`](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L154-R154): Updated the version of `azure/login` from `v1` to `v2` in multiple places. [[1]](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L154-R154) [[2]](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L182-R182) [[3]](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L272-R283)
* [`.github/workflows/dotnetcore.yml`](diffhunk://#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825L272-R283): Updated the version of `Azure/cli` from `v1.0.8` to `v2.0.0`.

Dependency version updates:

* Various `.csproj` files: Updated the versions of several dependencies, including `Azure.Security.KeyVault.Secrets`, `Azure.Extensions.AspNetCore.Configuration.Secrets`, `Azure.Data.Tables`, `Microsoft.NET.Sdk.Functions`, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `coverlet.collector`, `Selenium.WebDriver`, `Selenium.WebDriver.ChromeDriver`, `Microsoft.VisualStudio.Web.CodeGeneration.Design`, and `Microsoft.AspNetCore.TestHost`. [[1]](diffhunk://#diff-5f7dd1a40833b36eb91429c4d7175fe07d1c6dac43dd5f106a4a68d4a53698e1L23-R24) [[2]](diffhunk://#diff-5ecb412b0338c8c2f076a9f8ddd722b25d91d747fb1af8af3563217f36d32596L8-R8) [[3]](diffhunk://#diff-f3f7cbfc4a2f61efc4ce7838b9f045d68aca23451a8b0b7c172639e585a1fbf2L10-R12) [[4]](diffhunk://#diff-dfa811b1539172493e7666a0f45f1a5a246a9c14d80ee027b9fcdb53ac39c104L10-R18) [[5]](diffhunk://#diff-66496cf5cc1735fadc2669d40b7d2a314cfffb143bea3455eec7c041a72b733eL10-R15) [[6]](diffhunk://#diff-d348d77e37862d662d9d90ddc5eb3a1d488c998a41af70aa1939cfcd1495007aL24-R36)