### PR TITLE
Updated packages

### DIFF
--- a/src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj
+++ b/src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Azure.Identity" Version="1.10.4" />
+	  <PackageReference Include="Azure.Identity" Version="1.11.3" />
 	  <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 	  <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />

--- a/src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj
+++ b/src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
-		<PackageReference Include="Azure.Identity" Version="1.10.4" />
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
+		<PackageReference Include="Azure.Identity" Version="1.11.3" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj
+++ b/src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver" Version="4.19.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="123.0.6312.8600" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.20.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="124.0.6367.20100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj
+++ b/src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-		<PackageReference Include="Azure.Identity" Version="1.10.4" />
+		<PackageReference Include="Azure.Identity" Version="1.11.3" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj
+++ b/src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj
@@ -20,14 +20,14 @@
 
 	<ItemGroup>
 
-		<PackageReference Include="Azure.Identity" Version="1.10.4" />
+		<PackageReference Include="Azure.Identity" Version="1.11.3" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
 		<PackageReference Include="coverlet.msbuild" Version="6.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
This pull request primarily includes updates to various package versions across multiple project files in the solution. The most notable updates are the upgrade of the `Azure.Identity` package from version `1.10.4` to `1.11.3` in multiple projects, the upgrade of `Microsoft.NET.Sdk.Functions` from version `4.3.0` to `4.4.0` in the `DevOpsMetrics.Function` project, and the upgrade of `Selenium.WebDriver` and `Selenium.WebDriver.ChromeDriver` in the `DevOpsMetrics.FunctionalTests` project.

Package updates:

* [`src/DevOpsMetrics.Cmd/DevOpsMetrics.Cmd.csproj`](diffhunk://#diff-5f7dd1a40833b36eb91429c4d7175fe07d1c6dac43dd5f106a4a68d4a53698e1L22-R22): Updated `Azure.Identity` package from version `1.10.4` to `1.11.3`.
* [`src/DevOpsMetrics.Function/DevOpsMetrics.Function.csproj`](diffhunk://#diff-f3f7cbfc4a2f61efc4ce7838b9f045d68aca23451a8b0b7c172639e585a1fbf2L10-R11): Updated `Azure.Identity` package from version `1.10.4` to `1.11.3` and `Microsoft.NET.Sdk.Functions` from version `4.3.0` to `4.4.0`.
* [`src/DevOpsMetrics.FunctionalTests/DevOpsMetrics.FunctionalTests.csproj`](diffhunk://#diff-dfa811b1539172493e7666a0f45f1a5a246a9c14d80ee027b9fcdb53ac39c104L17-R18): Updated `Selenium.WebDriver` from version `4.19.0` to `4.20.0` and `Selenium.WebDriver.ChromeDriver` from version `123.0.6312.8600` to `124.0.6367.20100`.
* [`src/DevOpsMetrics.Service/DevOpsMetrics.Service.csproj`](diffhunk://#diff-66496cf5cc1735fadc2669d40b7d2a314cfffb143bea3455eec7c041a72b733eL11-R11): Updated `Azure.Identity` package from version `1.10.4` to `1.11.3`.
* [`src/DevOpsMetrics.Tests/DevOpsMetrics.Tests.csproj`](diffhunk://#diff-d348d77e37862d662d9d90ddc5eb3a1d488c998a41af70aa1939cfcd1495007aL23-R30): Updated `Azure.Identity` package from version `1.10.4` to `1.11.3` and `Microsoft.AspNetCore.TestHost` from version `8.0.3` to `8.0.4`.